### PR TITLE
feat: update to go 1.24.x

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -72,7 +72,7 @@ tools:
 
   - name: golangci-lint
     version:
-      want: v1.61.0
+      want: v1.64.2
     method: github-release
     with:
       repo: golangci/golangci-lint

--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -4,7 +4,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.23.x"
+    default: "1.24.x"
   cache-key-prefix:
     description: "Prefix all cache keys with this value"
     required: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 issues:
   max-same-issues: 25
+  uniq-by-line: false
 
   # TODO: enable this when we have coverage on docstring comments
 #  # The list of ids of default excludes to include or disable.
@@ -48,8 +49,7 @@ linters-settings:
     # If lower than 0, disable the check.
     # Default: 40
     statements: 50
-output:
-  uniq-by-line: false
+
 run:
   timeout: 10m
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/grant
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/anchore/bubbly v0.0.0-20231115205105-6542675d79fe


### PR DESCRIPTION
Update to building with go [1.24.x](https://tip.golang.org/doc/go1.24) so that the main module version gets set during go build