### PR TITLE
Fixes inconsistent version reporting between `grant --version` and `grant version` commands.

### DIFF
--- a/cmd/grant/cli/cli.go
+++ b/cmd/grant/cli/cli.go
@@ -13,7 +13,7 @@ func Application() *cobra.Command {
 		Use:     "grant",
 		Short:   "A license compliance tool for container images, SBOMs, filesystems, and more",
 		Long:    `Grant helps you view licenses for container images, SBOM documents, and filesystems. Apply filters and views that can help you build a picture of licenses in your SBOM.`,
-		Version: internal.ApplicationVersion,
+		Version: internal.ApplicationVersion(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// Set up logging based on verbose flag
 			verbose, _ := cmd.Flags().GetBool("verbose")

--- a/grant/response.go
+++ b/grant/response.go
@@ -108,7 +108,7 @@ type LicenseDetail struct {
 func NewRunResponse(argv []string, policy *Policy) *RunResponse {
 	return &RunResponse{
 		Tool:    internal.ApplicationName,
-		Version: internal.ApplicationVersion,
+		Version: internal.ApplicationVersion(),
 		Run: RunDetails{
 			Argv: argv,
 			Policy: PolicyConfig{

--- a/internal/grant.go
+++ b/internal/grant.go
@@ -70,9 +70,9 @@ func GetBuildInfo() BuildInfo {
 }
 
 // ApplicationVersion returns the current version for backward compatibility
-var ApplicationVersion = func() string {
+func ApplicationVersion() string {
 	if version != NotProvided {
 		return version
 	}
 	return "0.0.1"
-}()
+}

--- a/tests/cli/version_test.go
+++ b/tests/cli/version_test.go
@@ -18,7 +18,7 @@ func Test_VersionCommand(t *testing.T) {
 		{
 			name:             "text output",
 			command:          "--version",
-			expectedInOutput: []string{"[not provided]"},
+			expectedInOutput: []string{"grant version"},
 		},
 		{
 			name:    "long form",


### PR DESCRIPTION
  **Before:**
- `grant --version` → `grant version 0.0.1`
- `grant version` → `Version: 0.3.2` (correct version)

**After:**
- `grant --version` → `grant version 0.3.2-SNAPSHOT-436bf87`
- `grant version` → `Version: 0.3.2-SNAPSHOT-436bf87`

## Root Cause

The issue was in `internal/grant.go` where `ApplicationVersion` was implemented as a pre-computed variable that was evaluated at package load time, before `SetBuildInfo()` was called from `main()`. This caused it to always default to `"0.0.1"` instead of using the actual build-time version.

## Changes Made

- **`internal/grant.go`**: Changed `ApplicationVersion` from pre-computed variable to function
- **`cmd/grant/cli/cli.go`**: Updated to call `ApplicationVersion()` as function
- **`grant/response.go`**: Updated to call `ApplicationVersion()` as function
- **`tests/cli/version_test.go`**: Updated test expectation to match correct behavior

## Testing

- ✅ All unit tests pass (`make test`)
- ✅ All linting checks pass (`make lint`)
- ✅ Version-specific tests updated and passing
- ✅ Manual verification of both version commands showing consistent output

## Test Plan

```bash
# Build and test the fix
make build
./snapshot/darwin-build_darwin_arm64/grant --version
./snapshot/darwin-build_darwin_arm64/grant version
```

Both commands now report the same version information.

Closes #277

---
🤖 Generated with assistance from https://claude.ai/code