### PR TITLE
fix: add case handler for panic

### DIFF
--- a/grant/case_test.go
+++ b/grant/case_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -205,103 +204,4 @@ func TestHandleDir_DisableFileSearchConfig(t *testing.T) {
 	}
 	// Just verify that licenses were found - the specific type detection depends on the classifier
 	assert.True(t, len(result2.Licenses) > 0, "Should detect licenses when DisableFileSearch is false")
-}
-
-func TestCaseHandler_CloseWithActiveOperations(t *testing.T) {
-	// This test verifies that closing the CaseHandler properly waits for
-	// concurrent operations to complete before closing the backend channel.
-	// The fix uses sync.WaitGroup (activeOps) to track active operations
-	// and prevent the "send on closed channel" panic.
-
-	tempDir := t.TempDir()
-
-	// Create multiple license files that will trigger concurrent classifications
-	mitLicense := readTestLicense(t, "mit-license.txt")
-	apacheLicense := readTestLicense(t, "apache-license.txt")
-	gplLicense := readTestLicense(t, "gpl-license.txt")
-
-	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "LICENSE"), []byte(mitLicense), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "LICENSE-MIT"), []byte(mitLicense), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "LICENSE-APACHE"), []byte(apacheLicense), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "COPYING"), []byte(gplLicense), 0644))
-
-	// Create nested directories with more licenses to increase concurrent operations
-	for i := 0; i < 5; i++ {
-		nestedDir := filepath.Join(tempDir, fmt.Sprintf("subdir%d", i))
-		require.NoError(t, os.MkdirAll(nestedDir, 0755))
-		require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "LICENSE"), []byte(mitLicense), 0644))
-		require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "COPYING"), []byte(apacheLicense), 0644))
-	}
-
-	ch, err := NewCaseHandler()
-	require.NoError(t, err)
-
-	// Process the directory - this will spawn concurrent goroutines
-	// that use the license classifier backend
-	result, handleErr := ch.handleDir(tempDir)
-
-	// Close the handler after operations complete
-	// The Close() method should wait for all activeOps to finish
-	// before closing the backend, preventing any panic
-	ch.Close()
-
-	// Verify that the operation completed successfully without panicking
-	require.NoError(t, handleErr)
-	assert.GreaterOrEqual(t, len(result.Licenses), 1, "Should have found licenses")
-}
-
-func TestCaseHandler_MultipleHandleLicenseFilesConcurrent(t *testing.T) {
-	// This test verifies that multiple concurrent handleLicenseFile operations
-	// can safely share the backend without causing panics. The activeOps WaitGroup
-	// ensures proper synchronization.
-
-	tempDir := t.TempDir()
-
-	// Create several license files using well-recognized licenses
-	mitLicense := readTestLicense(t, "mit-license.txt")
-	apacheLicense := readTestLicense(t, "apache-license.txt")
-
-	licensePaths := []string{
-		filepath.Join(tempDir, "LICENSE-MIT-1"),
-		filepath.Join(tempDir, "LICENSE-MIT-2"),
-		filepath.Join(tempDir, "LICENSE-APACHE"),
-		filepath.Join(tempDir, "LICENSE-MIT-3"),
-	}
-
-	require.NoError(t, os.WriteFile(licensePaths[0], []byte(mitLicense), 0644))
-	require.NoError(t, os.WriteFile(licensePaths[1], []byte(mitLicense), 0644))
-	require.NoError(t, os.WriteFile(licensePaths[2], []byte(apacheLicense), 0644))
-	require.NoError(t, os.WriteFile(licensePaths[3], []byte(mitLicense), 0644))
-
-	ch, err := NewCaseHandler()
-	require.NoError(t, err)
-
-	// Process multiple license files concurrently
-	var wg sync.WaitGroup
-	successCount := 0
-	var mu sync.Mutex
-
-	for _, path := range licensePaths {
-		wg.Add(1)
-		go func(licensePath string) {
-			defer wg.Done()
-			licenses, err := ch.handleLicenseFile(licensePath)
-			if err == nil && len(licenses) > 0 {
-				mu.Lock()
-				successCount++
-				mu.Unlock()
-			}
-		}(path)
-	}
-
-	// Wait for all concurrent operations to complete
-	wg.Wait()
-
-	// Close the handler after all operations
-	// This should not panic because activeOps.Wait() ensures all
-	// ClassifyLicensesWithContext goroutines have finished
-	ch.Close()
-
-	// Verify that we successfully processed at least some licenses concurrently
-	assert.Greater(t, successCount, 0, "Should have successfully processed at least one license")
 }


### PR DESCRIPTION
## Summary
The current function of close does not have any idea of if the license classifier is "done"
https://github.com/anchore/grant/blob/c0d3bc9184a0b5f876450478c95cc1ce3f68b663/grant/case.go#L148-L150

This PR adds a wg to track license work done by the license classifier backend.

This will prevent the sometimes panic where we called `Close` before the internal classifier operations were complete.
