### PR TITLE
fix: check stdin handle

### DIFF
--- a/tests/cli/check_test.go
+++ b/tests/cli/check_test.go
@@ -37,3 +37,84 @@ func Test_CheckCmd(t *testing.T) {
 		})
 	}
 }
+
+func Test_CheckCmdStdin(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		stdin        string
+		wantErr      bool
+		wantInOutput []string
+		wantAbsent   []string
+	}{
+		{
+			name:    "no args and no stdin shows helpful error",
+			args:    []string{"check"},
+			wantErr: true,
+			wantInOutput: []string{
+				"no target specified and no input available on stdin",
+			},
+		},
+		{
+			name:    "piped stdin with no args reads from stdin",
+			args:    []string{"check"},
+			stdin:   `{"bomFormat":"CycloneDX","specVersion":"1.4","components":[]}`,
+			wantErr: false,
+			wantAbsent: []string{
+				"no target specified",
+				"requires at least 1 arg",
+			},
+		},
+		{
+			name:    "explicit args are used even when stdin is available",
+			args:    []string{"check", "../../grant/testdata/mit-license.txt"},
+			stdin:   "this should be ignored",
+			wantErr: false,
+			wantAbsent: []string{
+				"no target specified",
+			},
+		},
+		{
+			name:    "explicit dash reads from stdin",
+			args:    []string{"check", "-"},
+			stdin:   `{"bomFormat":"CycloneDX","specVersion":"1.4","components":[]}`,
+			wantErr: false,
+			wantAbsent: []string{
+				"no target specified",
+				"requires at least 1 arg",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command(grantTmpPath, tt.args...)
+			if tt.stdin != "" {
+				cmd.Stdin = strings.NewReader(tt.stdin)
+			}
+			output, err := cmd.CombinedOutput()
+			got := string(output)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("grant %s: got success, want error", strings.Join(tt.args, " "))
+				}
+			} else {
+				// Allow exit status 1 (policy violations) but not other errors
+				if err != nil && !strings.Contains(err.Error(), "exit status 1") {
+					t.Fatalf("grant %s: got unexpected error: %v\noutput: %s", strings.Join(tt.args, " "), err, got)
+				}
+			}
+
+			for _, want := range tt.wantInOutput {
+				if !strings.Contains(got, want) {
+					t.Errorf("grant %s: output does not contain %q\ngot: %s", strings.Join(tt.args, " "), want, got)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("grant %s: output unexpectedly contains %q\ngot: %s", strings.Join(tt.args, " "), absent, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Grant's `check` command did not support reading from stdin when no positional args were provided. 

Running `syft -o json dir:. | grant check` would fail with a cobra:
```
requires at least 1 arg
``` 
The list command already handled this case correctly via `parseListArgumentsWithStdin()`.

This change adds the same stdin-aware argument parsing to check, following the pattern already established in list.go:

- `cobra.MinimumNArgs(1)` → `cobra.ArbitraryArgs` to allow zero positional args
- A new `parseCheckArgumentsWithStdin()` function that resolves targets before the rest of runCheck executes. When no args are provided and stdin is a pipe/redirect, it synthesizes ["-"] as the target list. When no
  args and no stdin, it returns a clear error message instead of cobra's generic usage text.
- `runCheck` now operates on the resolved targets slice rather than raw args

Fixes #215 