### PR TITLE
fix: add --provenance=false for release image build flags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -112,6 +112,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -125,6 +126,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -138,6 +140,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/ppc64le"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -151,6 +154,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/s390x"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -164,6 +168,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -177,6 +182,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -190,6 +196,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/ppc64le"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -203,6 +210,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/s390x"
+      - "--provenance=false"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"


### PR DESCRIPTION
## Summary

GitHub Actions runner image `ubuntu22/20260209.31` bumped Docker from 28.0.4 to 29.1.5.
https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20260209.31

Docker 29 defaults to the containerd image store on fresh installs, which causes docker buildx build to attach provenance attestations.

This turns single-platform images into manifest lists. 

The current `goreleaser` configuration expects `application/vnd.docker.distribution.manifest.v2+json` and cannot work when the images are manifest lists with media type `application/vnd.oci.image.index.v1+json`

Adding this flag reverts the builds to be `application/vnd.docker.distribution.manifest.v2+json` by removing the attestation.