### PR TITLE
chore(deps): pin certain go dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,11 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "github.com/aquasecurity/go-pep440-version"
+      - dependency-name: "github.com/aquasecurity/go-version"
+      - dependency-name: "github.com/knqyf263/go-apk-version"
+      - dependency-name: "github.com/knqyf263/go-deb-version"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION

Prevent these dependencies from being automatically updated by
dependabot.
