### PR TITLE
Tighten workflow permissions, update release shape, and fix dependabot config

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -1,3 +1,5 @@
+cooldown: 7d
+
 tools:
   - name: grant
     version:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -18,19 +18,11 @@ updates:
       - dependency-name: "github.com/knqyf263/go-deb-version"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/bootstrap"
-    schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,8 +14,7 @@ on:
   schedule:
     - cron: '0 0 * * 3'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   analyze:
@@ -23,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       security-events: write
 
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,12 @@
 name: "Release"
+
+permissions: {}
+
+# there should never be two releases in progress at the same time
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
@@ -6,53 +14,25 @@ on:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
 
-permissions:
-  contents: read
-  checks: read
-
-env:
-  FORCE_COLOR: true
-
 jobs:
-  quality-gate:
-    environment: release
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          persist-credentials: false
 
-      - name: Check if tag already exists
-        # note: this will fail if the tag already exists
-        env:
-          VERSION_INPUT: ${{ github.event.inputs.version }}
-        run: |
-          # Validate and sanitize version input
-          if [[ ! "$VERSION_INPUT" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9-]+)?(\+[a-zA-Z0-9-]+)?$ ]]; then
-            echo "Invalid version format: '$VERSION_INPUT'. Expected format: v1.2.3 or v1.2.3-alpha or v1.2.3+build"
-            exit 1
-          fi
-          git tag "$VERSION_INPUT"
+  version-available:
+    uses: anchore/workflows/.github/workflows/check-version-available.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      version: ${{ github.event.inputs.version }}
 
-      - name: Check validations results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.2.0
-        id: validations
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Validations"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Quality gate
-        if: steps.validations.outputs.conclusion != 'success'
-        env:
-          VALIDATION_STATUS: ${{ steps.validations.outputs.conclusion }}
-        run: |
-          echo "Validations Status: $VALIDATION_STATUS"
-          false
+  check-gate:
+    permissions:
+      checks: read   # required for getting the status of specific check names
+    uses: anchore/workflows/.github/workflows/check-gate.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      # these are checks that should be run on pull-request and merges to main.
+      # we do NOT want to kick off a release if these have not been verified on main.
+      # Please see the validations.yaml workflow for the names that should be used here.
+      checks: '["Validations"]'
 
   release:
-    needs: [quality-gate]
+    needs: [check-gate, version-available]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -7,8 +7,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   FORCE_COLOR: true
@@ -19,6 +18,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Validations"
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:


### PR DESCRIPTION
Brings several CI/CD housekeeping items into alignment with org standards.

Changes:
- replace bespoke quality-gate job in release.yaml with the canonical check-gate + version-available reusable workflows (anchore/workflows@v0.4.0); add concurrency guard
- set top-level `permissions: {}` in codeql-analysis.yml, validate-github-actions.yaml, validations.yaml, and release.yaml; push any needed permissions to the job level
- switch dependabot gomod and github-actions intervals from daily to weekly; consolidate two github-actions entries into one using `directories`; add `/.github/actions/*` coverage
- add top-level `cooldown: 7d` to .binny.yaml

Notes:
- the existing release job body (tag, goreleaser, Slack notify, install-script) is unchanged