### PR TITLE
Update to dockers_v2 for goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,11 @@ jobs:
       - name: Bootstrap environment
         uses: anchore/go-make/.github/actions/setup@9de27be11ed73e2f9d5406a836a492b7d8aa1225 # v0.5.0
 
+      # dockers_v2 builds multi-platform manifests in a single buildx invocation, which requires a
+      # docker-container driver builder (the default builder on the runner cannot build multi-platform).
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee #v4.2.0
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -103,172 +103,56 @@ signs:
       - "--yes"
     artifacts: checksum
 
-dockers:
-  - image_templates:
-      - anchore/grant:{{.Tag}}-amd64
-      - ghcr.io/anchore/grant:{{.Tag}}-amd64
-    goarch: amd64
+# dockers_v2 builds multi-arch manifests in a single buildx invocation, reusing the
+# pre-built linux binaries. it replaces the legacy dockers + docker_manifests sections.
+dockers_v2:
+  - id: grant
     dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
+    # only COPY the linux binaries into the image
+    ids:
+      - linux-build
+    images:
+      - anchore/grant
+      - ghcr.io/anchore/grant
+    tags:
+      - "{{.Tag}}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
+    build_args:
+      BUILD_DATE: "{{.Date}}"
+      BUILD_VERSION: "{{.Version}}"
+      VCS_REF: "{{.FullCommit}}"
+      VCS_URL: "{{.GitURL}}"
+    # disable provenance attestations to keep the manifest free of unknown/unknown entries (parity with the legacy config)
+    flags:
       - "--provenance=false"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
+    # SBOMs are produced separately for the archives (see the sboms section); keep image build parity with the legacy config
+    sbom: "false"
 
-  - image_templates:
-      - anchore/grant:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/grant:{{.Tag}}-arm64v8
-    goarch: arm64
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--provenance=false"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/grant:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/grant:{{.Tag}}-ppc64le
-    goarch: ppc64le
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/ppc64le"
-      - "--provenance=false"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/grant:{{.Tag}}-s390x
-      - ghcr.io/anchore/grant:{{.Tag}}-s390x
-    goarch: s390x
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/s390x"
-      - "--provenance=false"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/grant:{{.Tag}}-debug-amd64
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-amd64
-    goarch: amd64
+  - id: grant-debug
     dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
+    ids:
+      - linux-build
+    images:
+      - anchore/grant
+      - ghcr.io/anchore/grant
+    tags:
+      - "{{.Tag}}-debug"
+      - debug
+    platforms:
+      - linux/amd64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
+    build_args:
+      BUILD_DATE: "{{.Date}}"
+      BUILD_VERSION: "{{.Version}}"
+      VCS_REF: "{{.FullCommit}}"
+      VCS_URL: "{{.GitURL}}"
+    flags:
       - "--provenance=false"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/grant:{{.Tag}}-debug-arm64v8
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-arm64v8
-    goarch: arm64
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--provenance=false"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/grant:{{.Tag}}-debug-ppc64le
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-ppc64le
-    goarch: ppc64le
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/ppc64le"
-      - "--provenance=false"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/grant:{{.Tag}}-debug-s390x
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-s390x
-    goarch: s390x
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/s390x"
-      - "--provenance=false"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-docker_manifests:
-  - name_template: anchore/grant:latest
-    image_templates:
-      - anchore/grant:{{.Tag}}-amd64
-      - anchore/grant:{{.Tag}}-arm64v8
-      - anchore/grant:{{.Tag}}-ppc64le
-      - anchore/grant:{{.Tag}}-s390x
-
-  - name_template: ghcr.io/anchore/grant:latest
-    image_templates:
-      - ghcr.io/anchore/grant:{{.Tag}}-amd64
-      - ghcr.io/anchore/grant:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/grant:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/grant:{{.Tag}}-s390x
-
-  - name_template: anchore/grant:{{.Tag}}
-    image_templates:
-      - anchore/grant:{{.Tag}}-amd64
-      - anchore/grant:{{.Tag}}-arm64v8
-      - anchore/grant:{{.Tag}}-ppc64le
-      - anchore/grant:{{.Tag}}-s390x
-
-  - name_template: ghcr.io/anchore/grant:{{.Tag}}
-    image_templates:
-      - ghcr.io/anchore/grant:{{.Tag}}-amd64
-      - ghcr.io/anchore/grant:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/grant:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/grant:{{.Tag}}-s390x
-
-  - name_template: anchore/grant:debug
-    image_templates:
-      - anchore/grant:{{.Tag}}-debug-amd64
-      - anchore/grant:{{.Tag}}-debug-arm64v8
-      - anchore/grant:{{.Tag}}-debug-ppc64le
-      - anchore/grant:{{.Tag}}-debug-s390x
-
-  - name_template: ghcr.io/anchore/grant:debug
-    image_templates:
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-amd64
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-arm64v8
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-ppc64le
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-s390x
-
-  - name_template: anchore/grant:{{.Tag}}-debug
-    image_templates:
-      - anchore/grant:{{.Tag}}-debug-amd64
-      - anchore/grant:{{.Tag}}-debug-arm64v8
-      - anchore/grant:{{.Tag}}-debug-ppc64le
-      - anchore/grant:{{.Tag}}-debug-s390x
-
-  - name_template: ghcr.io/anchore/grant:{{.Tag}}-debug
-    image_templates:
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-amd64
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-arm64v8
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-ppc64le
-      - ghcr.io/anchore/grant:{{.Tag}}-debug-s390x
+    sbom: "false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp
 
-COPY grant /
+# dockers_v2 lays the binaries out per-platform in the build context (e.g. linux/arm64/grant),
+# so select the right one via the buildx-provided TARGETOS/TARGETARCH args
+ARG TARGETOS
+ARG TARGETARCH
+COPY ${TARGETOS}/${TARGETARCH}/grant /grant
 
 ARG BUILD_DATE
 ARG BUILD_VERSION

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -3,7 +3,11 @@ FROM gcr.io/distroless/static-debian12:debug-nonroot
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp
 
-COPY grant /
+# dockers_v2 lays the binaries out per-platform in the build context (e.g. linux/arm64/grant),
+# so select the right one via the buildx-provided TARGETOS/TARGETARCH args
+ARG TARGETOS
+ARG TARGETARCH
+COPY ${TARGETOS}/${TARGETARCH}/grant /grant
 
 USER nonroot
 


### PR DESCRIPTION
For the next release we can use the [dockers_v2](https://goreleaser.com/customization/package/dockers_v2/) approach for goreleaser 