### PR TITLE
feat: include java group in finding name to distinguish java packages

### DIFF
--- a/grant/package.go
+++ b/grant/package.go
@@ -1,6 +1,10 @@
 package grant
 
-import syftPkg "github.com/anchore/syft/syft/pkg"
+import (
+	"strings"
+
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
 
 // PackageID is a unique identifier for a package that is tracked by grant
 // It's usually provided by the SBOM; It's calculated if an SBOM is generated
@@ -25,10 +29,37 @@ func ConvertSyftPackage(p syftPkg.Package) *Package {
 	}
 
 	return &Package{
-		Name:      p.Name,
+		Name:      packageNameFromSyft(p),
 		Version:   p.Version,
 		Type:      string(p.Type),
 		Licenses:  ConvertSyftLicenses(p.Licenses),
 		Locations: packageLocations,
 	}
+}
+
+func packageNameFromSyft(p syftPkg.Package) string {
+	name := p.Name
+
+	switch metadata := p.Metadata.(type) {
+	case syftPkg.JavaArchive:
+		return packageNameFromJavaMetadata(name, metadata.PomProperties)
+	case *syftPkg.JavaArchive:
+		if metadata != nil {
+			return packageNameFromJavaMetadata(name, metadata.PomProperties)
+		}
+	}
+
+	return name
+}
+
+func packageNameFromJavaMetadata(name string, pomProperties *syftPkg.JavaPomProperties) string {
+	groupID := ""
+	if pomProperties != nil {
+		groupID = strings.TrimSpace(pomProperties.GroupID)
+	}
+	if groupID == "" || name == "" || name == groupID || strings.HasPrefix(name, groupID+".") {
+		return name
+	}
+
+	return groupID + "." + name
 }

--- a/grant/package_test.go
+++ b/grant/package_test.go
@@ -1,0 +1,57 @@
+package grant
+
+import (
+	"testing"
+
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertSyftPackage_UsesMavenGroupIDInName(t *testing.T) {
+	tests := []struct {
+		name     string
+		syftPkg  pkg.Package
+		expected string
+	}{
+		{
+			name: "prefixes java package name with pom group id",
+			syftPkg: pkg.Package{
+				Name:    "slf4j-api",
+				Version: "2.0.17",
+				Type:    pkg.JavaPkg,
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{GroupID: "org.slf4j"},
+				},
+			},
+			expected: "org.slf4j.slf4j-api",
+		},
+		{
+			name: "does not double-prefix a name already including the group id",
+			syftPkg: pkg.Package{
+				Name:    "org.slf4j.slf4j-api",
+				Version: "2.0.17",
+				Type:    pkg.JavaPkg,
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{GroupID: "org.slf4j"},
+				},
+			},
+			expected: "org.slf4j.slf4j-api",
+		},
+		{
+			name: "leaves non-java package names unchanged",
+			syftPkg: pkg.Package{
+				Name:    "requests",
+				Version: "2.32.3",
+				Type:    pkg.PythonPkg,
+			},
+			expected: "requests",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converted := ConvertSyftPackage(tt.syftPkg)
+			assert.Equal(t, tt.expected, converted.Name)
+		})
+	}
+}


### PR DESCRIPTION
This MR would make java based findings more clear. Right now only the package name is added. To distinguish multiple packages with the same name but different groups, the group should be added in the package name.

Are you open for this change?