### PR TITLE
fix: guard against panic on malformed SPDX license expression

### DIFF
--- a/grant/license.go
+++ b/grant/license.go
@@ -1,6 +1,7 @@
 package grant
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/github/go-spdx/v2/spdxexp"
@@ -75,8 +76,26 @@ func ConvertSyftLicenses(set syftPkg.LicenseSet) (licenses []License) {
 	return licenses
 }
 
+// safeExtractLicenses wraps spdxexp.ExtractLicenses so a malformed SPDX
+// expression cannot take down the whole scan. The upstream parser
+// (github.com/github/go-spdx) panics on some inputs, for example an expression
+// with a dangling opening parenthesis like "MIT AND (". SBOM license fields
+// flow through here unvalidated, so a single malformed value in an SBOM would
+// otherwise crash grant. syft guards its own call to this parser for
+// the same reason (see anchore/syft#1837); grant does the same here and lets the
+// existing error path fall back to treating the value as a non-SPDX license.
+func safeExtractLicenses(expression string) (extracted []string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			extracted = nil
+			err = fmt.Errorf("recovered from panic parsing SPDX expression %q: %v", expression, r)
+		}
+	}()
+	return spdxexp.ExtractLicenses(expression)
+}
+
 func handleSPDXLicense(license syftPkg.License, licenses []License, licenseLocations []string, checked map[string]bool) []License {
-	extractedLicenses, err := spdxexp.ExtractLicenses(license.SPDXExpression)
+	extractedLicenses, err := safeExtractLicenses(license.SPDXExpression)
 	if err != nil {
 		// log.Errorf("unable to extract licenses from SPDX expression: %s", license.SPDXExpression)
 		return addNonSPDXLicense(licenses, license, licenseLocations)

--- a/grant/license_test.go
+++ b/grant/license_test.go
@@ -1,0 +1,44 @@
+package grant
+
+import (
+	"testing"
+
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
+
+// TestConvertSyftLicenses_MalformedSPDXExpressionDoesNotPanic feeds a license
+// whose SPDXExpression is a malformed expression with a dangling opening
+// parenthesis. This is the shape that reaches handleSPDXLicense when grant
+// decodes an SBOM whose license field is malformed. The upstream SPDX parser
+// panics on this input, so without the guard in handleSPDXLicense the whole scan
+// would crash. The expression should instead fall back to a non-SPDX license.
+func TestConvertSyftLicenses_MalformedSPDXExpressionDoesNotPanic(t *testing.T) {
+	malformed := []string{
+		"MIT AND (",
+		"(",
+		"(((((",
+		"MIT OR (",
+	}
+
+	for _, expr := range malformed {
+		expr := expr
+		t.Run(expr, func(t *testing.T) {
+			set := syftPkg.NewLicenseSet(syftPkg.License{Value: expr, SPDXExpression: expr})
+
+			// must not panic
+			got := ConvertSyftLicenses(set)
+
+			if len(got) != 1 {
+				t.Fatalf("expected 1 license, got %d", len(got))
+			}
+			// the malformed expression should be carried as a plain name, not
+			// treated as a valid SPDX expression
+			if got[0].IsSPDX() {
+				t.Fatalf("expected malformed expression %q to fall back to a non-SPDX license, got SPDX license %q", expr, got[0].SPDXExpression)
+			}
+			if got[0].Name != expr {
+				t.Fatalf("expected fallback license name %q, got %q", expr, got[0].Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

`spdxexp.ExtractLicenses` can panic (nil pointer dereference) on some malformed SPDX expressions. The one I hit is an expression with a dangling opening parenthesis, for example `MIT AND (` (also plain `(`, `(((((`, `MIT OR (`).

`handleSPDXLicense` in `grant/license.go` calls it and only handles the returned `error`, not a panic. Because SBOM license fields are decoded straight into `pkg.License.SPDXExpression` without re-validation (syft's json decoder copies the field through as-is), a single malformed license value in an input SBOM takes down the whole scan rather than being skipped.

### Fix

Wrap the call in a small `safeExtractLicenses` helper that recovers from the panic and returns an error, so the existing error branch falls back to treating the value as a non-SPDX license. Minimal change, existing behavior for valid expressions is unchanged.

syft guards its own call to this same parser for exactly this reason, see the recover in `license.ParseExpression` and anchore/syft#1837. This just brings grant in line.

### Test

Added `TestConvertSyftLicenses_MalformedSPDXExpressionDoesNotPanic`, which drives the real `ConvertSyftLicenses` entry point with the malformed expressions above and asserts they fall back to a non-SPDX license instead of panicking.

Before the guard (reverting just the one call back to `spdxexp.ExtractLicenses`):

```
--- FAIL: TestConvertSyftLicenses_MalformedSPDXExpressionDoesNotPanic/MIT_AND_(
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
```

After:

```
--- PASS: TestConvertSyftLicenses_MalformedSPDXExpressionDoesNotPanic
ok      github.com/anchore/grant/grant
```

`go build ./...` and `go test ./grant/` both pass.

This is a robustness fix for malformed input, not a security report.
