### PR TITLE
fix: resolve SPDX expressions that use the WITH operator

### DIFF
--- a/grant/license.go
+++ b/grant/license.go
@@ -113,6 +113,15 @@ func handleSPDXLicense(license syftPkg.License, licenses []License, licenseLocat
 		// we have what seems to be a valid SPDX license ID, let's try and get more info about it
 		spdxLicense, err := spdxlicense.GetLicenseByID(extractedLicense)
 		if err != nil {
+			// The parser returns "<license> WITH <exception>" as a single atom, but the
+			// SPDX license list is indexed by license ID alone, so the lookup above can
+			// only fail for these. Retry with the license the exception applies to; the
+			// full expression is still what ends up on the resulting License.
+			if base, ok := licenseFromExceptionExpression(extractedLicense); ok {
+				spdxLicense, err = spdxlicense.GetLicenseByID(base)
+			}
+		}
+		if err != nil {
 			log.Errorf("unable to get license by ID: %s; no matching spdx id found", extractedLicense)
 			// if we can't find a matching SPDX license, just add the license as-is
 			// TODO: best matching against the spdx list index
@@ -134,6 +143,22 @@ func handleSPDXLicense(license syftPkg.License, licenses []License, licenseLocat
 		})
 	}
 	return licenses
+}
+
+// licenseFromExceptionExpression returns the license an SPDX "WITH" expression
+// applies to, for example "Apache-2.0" from "Apache-2.0 WITH LLVM-exception".
+func licenseFromExceptionExpression(expression string) (string, bool) {
+	parts := strings.SplitN(expression, " WITH ", 2)
+	if len(parts) != 2 {
+		return "", false
+	}
+
+	license := strings.TrimRight(strings.TrimSpace(parts[0]), "+")
+	if license == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", false
+	}
+
+	return license, true
 }
 
 func addNonSPDXLicense(licenses []License, license syftPkg.License, locations []string) []License {

--- a/grant/license_test.go
+++ b/grant/license_test.go
@@ -42,3 +42,54 @@ func TestConvertSyftLicenses_MalformedSPDXExpressionDoesNotPanic(t *testing.T) {
 		})
 	}
 }
+
+// TestConvertSyftLicenses_SPDXExpressionWithException covers SPDX expressions
+// that use the WITH operator. The upstream parser hands these back as a single
+// atom ("Apache-2.0 WITH LLVM-exception"), which is not a key in the SPDX
+// license list, so grant used to log "unable to get license by ID" and fall back
+// to an unresolved license.
+func TestConvertSyftLicenses_SPDXExpressionWithException(t *testing.T) {
+	tests := []struct {
+		expression  string
+		wantSPDX    []string
+		wantLicense []string
+	}{
+		{
+			expression:  "Apache-2.0 WITH LLVM-exception",
+			wantSPDX:    []string{"Apache-2.0 WITH LLVM-exception"},
+			wantLicense: []string{"Apache-2.0"},
+		},
+		{
+			expression:  "GPL-2.0-only WITH Classpath-exception-2.0",
+			wantSPDX:    []string{"GPL-2.0-only WITH Classpath-exception-2.0"},
+			wantLicense: []string{"GPL-2.0-only"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.expression, func(t *testing.T) {
+			set := syftPkg.NewLicenseSet(syftPkg.License{Value: tt.expression, SPDXExpression: tt.expression})
+
+			got := ConvertSyftLicenses(set)
+
+			if len(got) != len(tt.wantSPDX) {
+				t.Fatalf("expected %d licenses, got %d", len(tt.wantSPDX), len(got))
+			}
+			for i, want := range tt.wantSPDX {
+				if !got[i].IsSPDX() {
+					t.Fatalf("expected %q to resolve to an SPDX license, got name %q", tt.expression, got[i].Name)
+				}
+				if got[i].SPDXExpression != want {
+					t.Errorf("got SPDX expression %q, want %q", got[i].SPDXExpression, want)
+				}
+				if got[i].LicenseID != tt.wantLicense[i] {
+					t.Errorf("got license id %q, want %q", got[i].LicenseID, tt.wantLicense[i])
+				}
+				if got[i].Name == "" {
+					t.Errorf("expected the license name to be populated from the SPDX list")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #500

## Problem

`spdxexp.ExtractLicenses` hands back a `WITH` expression as a single atom, and the SPDX license list is indexed by license ID alone, so the lookup in `handleSPDXLicense` can never succeed for it. Probed against the parser and index this repo already uses:

```
expr="Apache-2.0 WITH LLVM-exception"                       atoms=[Apache-2.0 WITH LLVM-exception]
  lookup("Apache-2.0 WITH LLVM-exception") -> SPDX license Apache-2.0 WITH LLVM-exception not found

expr="Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT"  atoms=[Apache-2.0  Apache-2.0 WITH LLVM-exception  MIT]
  lookup("Apache-2.0")                     -> <nil>
  lookup("Apache-2.0 WITH LLVM-exception") -> SPDX license Apache-2.0 WITH LLVM-exception not found
  lookup("MIT")                            -> <nil>
```

So every component carrying an exception logs `unable to get license by ID` and falls through to `addNonSPDXLicense`, which is the `Unknown` in the report from the issue.

## Change

When the lookup fails and the atom is a `WITH` expression, retry with the license the exception applies to.

Deliberately narrow:

- The **full expression stays** on the resulting `License.SPDXExpression`. Policy matching goes through `License.String()`, which returns that expression, so no rule that matches today starts or stops matching.
- The retry only happens **after** the direct lookup fails, so nothing that resolves today takes a different path.
- A trailing `+` on the license part is trimmed, matching what the surrounding code already does for plain atoms.

What changes is that the license resolves: name, reference, details URL and OSI status now come from the base license instead of being empty. The exception itself is not recorded separately — `License` has no field for it, and adding one would change the JSON output — but it remains visible in the expression.

## Tests

`TestConvertSyftLicenses_SPDXExpressionWithException` covers `Apache-2.0 WITH LLVM-exception` and `GPL-2.0-only WITH Classpath-exception-2.0`.

With `grant/license.go` reverted to its state on `main`:

```
--- FAIL: TestConvertSyftLicenses_SPDXExpressionWithException/Apache-2.0_WITH_LLVM-exception
    license_test.go:81: expected "Apache-2.0 WITH LLVM-exception" to resolve to an SPDX license, got name "Apache-2.0 WITH LLVM-exception"
--- FAIL: TestConvertSyftLicenses_SPDXExpressionWithException/GPL-2.0-only_WITH_Classpath-exception-2.0
--- PASS: TestConvertSyftLicenses_MalformedSPDXExpressionDoesNotPanic
```

With the change:

```
ok  	github.com/anchore/grant/grant	17.443s
```
