### PR TITLE
fix: wrap wide license columns to the terminal width

### DIFF
--- a/cmd/grant/cli/command/check.go
+++ b/cmd/grant/cli/command/check.go
@@ -471,6 +471,7 @@ func printPackageTableUnlicensed(packages []grant.PackageFinding) error {
 
 	// Use uppercase headers to match grype style
 	t.AppendHeader(table.Row{"NAME", "VERSION", "LICENSE STATUS"})
+	internal.WrapWideColumns(t, "LICENSE STATUS")
 
 	// Add rows for packages without licenses
 	for _, pkg := range packages {

--- a/cmd/grant/cli/command/list.go
+++ b/cmd/grant/cli/command/list.go
@@ -542,6 +542,7 @@ func printFilteredPackageTable(packages []grant.PackageFinding) error {
 
 	// Set headers with uppercase to match grype style
 	t.AppendHeader(table.Row{"NAME", "VERSION", "LICENSE", "RISK"})
+	internal.WrapWideColumns(t, "LICENSE")
 
 	// Add rows for matching packages
 	for _, pkg := range packages {
@@ -673,6 +674,7 @@ func printAggregatedLicenseTable(packages []grant.PackageFinding) error {
 
 	// Set headers
 	t.AppendHeader(table.Row{"LICENSE", "PACKAGES", "RISK"})
+	internal.WrapWideColumns(t, "LICENSE", "PACKAGES")
 
 	// Add rows
 	for _, lc := range licenseCounts {
@@ -910,6 +912,7 @@ func outputRiskGroupedTable(target grant.TargetResult) error {
 
 	// Set headers
 	t.AppendHeader(table.Row{"RISK CATEGORY", "LICENSES", "PACKAGES"})
+	internal.WrapWideColumns(t, "LICENSES", "PACKAGES")
 
 	// Add rows in order of risk severity
 	categoryOrder := []string{riskCategoryStrongCopyleft, riskCategoryWeakCopyleft, riskCategoryPermissive}

--- a/cmd/grant/cli/internal/output.go
+++ b/cmd/grant/cli/internal/output.go
@@ -244,6 +244,7 @@ func (o *Output) printPackageTable(packages []grant.PackageFinding) error {
 
 	// Set headers with uppercase to match grype style
 	t.AppendHeader(table.Row{"NAME", "VERSION", "LICENSE", "RISK"})
+	WrapWideColumns(t, "LICENSE")
 
 	// Add rows for denied packages only
 	for _, pkg := range deniedPackages {
@@ -432,6 +433,7 @@ func (o *Output) printAggregatedLicenseTable(packages []grant.PackageFinding) er
 
 	// Set headers
 	t.AppendHeader(table.Row{"LICENSE", "PACKAGES", "RISK"})
+	WrapWideColumns(t, "LICENSE", "PACKAGES")
 
 	// Add rows
 	for _, lc := range licenseCounts {

--- a/cmd/grant/cli/internal/table.go
+++ b/cmd/grant/cli/internal/table.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"github.com/jedib0t/go-pretty/v6/table"
+)
+
+// minWrappedColumnWidth keeps a wrapped column readable on a narrow terminal.
+const minWrappedColumnWidth = 20
+
+// wrappedColumnWidth returns the width to allow a wide text column, given the
+// width of the terminal. A terminal width of 0 means the width is unknown (the
+// output is not a terminal), in which case nothing should be wrapped.
+func wrappedColumnWidth(terminalWidth int) int {
+	if terminalWidth <= 0 {
+		return 0
+	}
+
+	width := terminalWidth / 2
+	if width < minWrappedColumnWidth {
+		width = minWrappedColumnWidth
+	}
+
+	return width
+}
+
+// WrapWideColumns limits the named columns to a share of the terminal width, so
+// that a package carrying many licenses wraps instead of pushing the row far
+// past the edge of the screen. It is a no-op when stdout is not a terminal, so
+// piped and redirected output keeps its current shape.
+func WrapWideColumns(t table.Writer, columns ...string) {
+	width := wrappedColumnWidth(TerminalWidth())
+	if width == 0 {
+		return
+	}
+
+	configs := make([]table.ColumnConfig, 0, len(columns))
+	for _, name := range columns {
+		configs = append(configs, table.ColumnConfig{Name: name, WidthMax: width})
+	}
+
+	t.SetColumnConfigs(configs)
+}

--- a/cmd/grant/cli/internal/table_test.go
+++ b/cmd/grant/cli/internal/table_test.go
@@ -1,0 +1,25 @@
+package internal
+
+import "testing"
+
+func TestWrappedColumnWidth(t *testing.T) {
+	tests := []struct {
+		name          string
+		terminalWidth int
+		want          int
+	}{
+		{name: "unknown width does not wrap", terminalWidth: 0, want: 0},
+		{name: "negative width does not wrap", terminalWidth: -1, want: 0},
+		{name: "wide terminal gets half its width", terminalWidth: 178, want: 89},
+		{name: "narrow terminal keeps a readable minimum", terminalWidth: 30, want: minWrappedColumnWidth},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := wrappedColumnWidth(tt.terminalWidth); got != tt.want {
+				t.Errorf("wrappedColumnWidth(%d) = %d, want %d", tt.terminalWidth, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/grant/cli/internal/terminal.go
+++ b/cmd/grant/cli/internal/terminal.go
@@ -20,3 +20,19 @@ func IsTerminalError() bool {
 func IsTerminalInput() bool {
 	return term.IsTerminal(int(os.Stdin.Fd())) // #nosec G115 -- file descriptors are safe to convert to int
 }
+
+// TerminalWidth returns the width of the terminal attached to stdout, or 0 when
+// stdout is not a terminal or the size cannot be determined. Callers use 0 to
+// mean "leave the output alone", so redirected and piped output is unchanged.
+func TerminalWidth() int {
+	if !IsTerminalOutput() {
+		return 0
+	}
+
+	width, _, err := term.GetSize(int(os.Stdout.Fd())) // #nosec G115 -- file descriptors are safe to convert to int
+	if err != nil || width <= 0 {
+		return 0
+	}
+
+	return width
+}


### PR DESCRIPTION
Fixes #276

## Problem

A package that carries several licenses makes the license cell very wide, so the row runs far past the edge of the terminal and the table becomes hard to read (the issue shows a `jasper-libs` row spilling across the screen).

The tables are built with go-pretty but no column width is configured anywhere, so a cell is rendered at its natural width regardless of how wide the terminal actually is.

## Change

Adds a small helper in `cmd/grant/cli/internal`:

- `TerminalWidth()` — the width of the terminal attached to stdout, or `0` when stdout is not a terminal or the size can't be determined (`golang.org/x/term` is already a dependency).
- `WrapWideColumns(t, columns...)` — sets `WidthMax` on the named columns so go-pretty wraps inside the column instead of widening the row.

Applied to the six tables that carry a license column (`output.go` ×2, `list.go` ×3, `check.go` ×1), matched by header name rather than index.

Two deliberate properties:

- **Redirected output is untouched.** When stdout isn't a terminal the helper returns early and sets no column config, so piping to a file or another process produces exactly the same bytes as today. That keeps the CLI tests and any downstream parsing unaffected.
- **Wrapping, not truncating**, so no license information is lost.

The share of the terminal given to the license column (half, with a floor of 20 columns) is a heuristic — happy to change the split or make it configurable if you'd prefer something else.

## Tests

`wrappedColumnWidth` is a pure function so the width policy is testable without a TTY; `TestWrappedColumnWidth` covers the unknown-width, negative, wide-terminal and narrow-terminal cases.

```
=== RUN   TestWrappedColumnWidth
--- PASS: TestWrappedColumnWidth/unknown_width_does_not_wrap
--- PASS: TestWrappedColumnWidth/negative_width_does_not_wrap
--- PASS: TestWrappedColumnWidth/wide_terminal_gets_half_its_width
--- PASS: TestWrappedColumnWidth/narrow_terminal_keeps_a_readable_minimum
ok  	github.com/anchore/grant/cmd/grant/cli/internal	0.124s
```

`go build ./...` is clean across the repo. I wasn't able to finish a full `go test ./...` locally — the machine I had available couldn't get through the CLI integration suite in reasonable time — so I'd lean on CI for that.
