### PR TITLE
feat: distinguish java packages sharing an artifact id

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -3,6 +3,16 @@ cooldown: 7d
 # note: we are inheriting tool definitions from anchore/go-make .binny.yaml, so we only need to specify tools here that
 # are not already defined there (or that we want to override with different versions)
 tools:
+  # override: go-make pins v2.11.4, which is built with go1.26 and cannot read the export data
+  # emitted by the go 1.27 toolchain CI resolves ("export data version 4 is greater than maximum
+  # supported version 2"). v2.13.2 is built with go1.27.
+  - name: golangci-lint
+    version:
+      want: v2.13.2
+    method: github-release
+    with:
+      repo: golangci/golangci-lint
+
   # used to dogfood grant's license check against its own dependencies
   - name: grant
     version:

--- a/cmd/grant/cli/command/list.go
+++ b/cmd/grant/cli/command/list.go
@@ -602,7 +602,7 @@ func printAggregatedLicenseTable(packages []grant.PackageFinding) error {
 	// First, deduplicate packages by qualified name@version
 	uniquePackages := make(map[string]grant.PackageFinding)
 	for _, pkg := range packages {
-		packageKey := pkg.Coordinate() + "@" + pkg.Version
+		packageKey := pkg.QualifiedName() + "@" + pkg.Version
 		uniquePackages[packageKey] = pkg
 	}
 
@@ -610,7 +610,7 @@ func printAggregatedLicenseTable(packages []grant.PackageFinding) error {
 	licensePackages := make(map[string]map[string]bool)
 
 	for _, pkg := range uniquePackages {
-		packageKey := pkg.Coordinate() + "@" + pkg.Version
+		packageKey := pkg.QualifiedName() + "@" + pkg.Version
 
 		if len(pkg.Licenses) == 0 {
 			// Package with no licenses
@@ -713,7 +713,7 @@ func filterResultByPackage(result *grant.RunResponse, packageName string) *grant
 
 		// Filter packages by name, accepting either the bare name or the group-qualified form
 		for _, pkg := range target.Evaluation.Findings.Packages {
-			if pkg.Name == packageName || pkg.Coordinate() == packageName {
+			if pkg.Name == packageName || pkg.QualifiedName() == packageName {
 				matchedPackages = append(matchedPackages, pkg)
 			}
 		}
@@ -867,7 +867,7 @@ func outputRiskGroupedTable(target grant.TargetResult) error {
 
 	// Process each package
 	for _, pkg := range target.Evaluation.Findings.Packages {
-		packageKey := pkg.Coordinate() + "@" + pkg.Version
+		packageKey := pkg.QualifiedName() + "@" + pkg.Version
 
 		for _, license := range pkg.Licenses {
 			licenseKey := license.ID
@@ -990,44 +990,48 @@ func displayPackageDetails(result *grant.RunResponse, packageName string) error 
 		fmt.Printf("Type:     %s\n", pkg.Type)
 		fmt.Printf("ID:       %s\n", pkg.ID)
 
-		// Display licenses with new formatting
-		if len(pkg.Licenses) == 0 {
-			fmt.Printf("Licenses: (no licenses found)\n")
-		} else {
-			fmt.Printf("Licenses (%d):\n", len(pkg.Licenses))
-
-			for _, license := range pkg.Licenses {
-				// Use license ID or name as display name
-				licenseName := license.ID
-				if licenseName == "" {
-					licenseName = license.Name
-				}
-				if licenseName == "" {
-					licenseName = "(unknown)"
-				}
-
-				fmt.Println()
-				// Format with bullet point and make license name clickable if we have a reference
-				if license.Reference != "" {
-					// Make it blue and underlined to indicate it's clickable
-					fmt.Printf("• \x1b]8;;%s\x1b\\\x1b[34;4m%s\x1b[0m\x1b]8;;\x1b\\\n", license.Reference, licenseName)
-				} else {
-					fmt.Printf("• %s\n", licenseName)
-				}
-
-				// Format OSI Approved status with warning if false
-				osiStatus := fmt.Sprintf("OSI Approved: %t", license.IsOsiApproved)
-				if !license.IsOsiApproved {
-					osiStatus = color.Yellow.Sprintf("⚠️  OSI Approved: false")
-				}
-
-				fmt.Printf("  %s | Deprecated: %t\n", osiStatus, license.IsDeprecatedLicenseID)
-				if len(license.Evidence) > 0 {
-					fmt.Printf("  Evidence: %v\n", license.Evidence)
-				}
-			}
-		}
+		displayPackageLicenses(pkg.Licenses)
 	}
 
 	return nil
+}
+
+func displayPackageLicenses(licenses []grant.LicenseDetail) {
+	if len(licenses) == 0 {
+		fmt.Printf("Licenses: (no licenses found)\n")
+		return
+	}
+
+	fmt.Printf("Licenses (%d):\n", len(licenses))
+
+	for _, license := range licenses {
+		// Use license ID or name as display name
+		licenseName := license.ID
+		if licenseName == "" {
+			licenseName = license.Name
+		}
+		if licenseName == "" {
+			licenseName = "(unknown)"
+		}
+
+		fmt.Println()
+		// Format with bullet point and make license name clickable if we have a reference
+		if license.Reference != "" {
+			// Make it blue and underlined to indicate it's clickable
+			fmt.Printf("• \x1b]8;;%s\x1b\\\x1b[34;4m%s\x1b[0m\x1b]8;;\x1b\\\n", license.Reference, licenseName)
+		} else {
+			fmt.Printf("• %s\n", licenseName)
+		}
+
+		// Format OSI Approved status with warning if false
+		osiStatus := fmt.Sprintf("OSI Approved: %t", license.IsOsiApproved)
+		if !license.IsOsiApproved {
+			osiStatus = color.Yellow.Sprintf("⚠️  OSI Approved: false")
+		}
+
+		fmt.Printf("  %s | Deprecated: %t\n", osiStatus, license.IsDeprecatedLicenseID)
+		if len(license.Evidence) > 0 {
+			fmt.Printf("  Evidence: %v\n", license.Evidence)
+		}
+	}
 }

--- a/cmd/grant/cli/command/list.go
+++ b/cmd/grant/cli/command/list.go
@@ -599,10 +599,10 @@ func formatLicenses(licenses []grant.LicenseDetail) string {
 
 // printAggregatedLicenseTable prints licenses grouped by license name with package counts
 func printAggregatedLicenseTable(packages []grant.PackageFinding) error {
-	// First, deduplicate packages by name@version
+	// First, deduplicate packages by qualified name@version
 	uniquePackages := make(map[string]grant.PackageFinding)
 	for _, pkg := range packages {
-		packageKey := pkg.Name + "@" + pkg.Version
+		packageKey := pkg.Coordinate() + "@" + pkg.Version
 		uniquePackages[packageKey] = pkg
 	}
 
@@ -610,7 +610,7 @@ func printAggregatedLicenseTable(packages []grant.PackageFinding) error {
 	licensePackages := make(map[string]map[string]bool)
 
 	for _, pkg := range uniquePackages {
-		packageKey := pkg.Name + "@" + pkg.Version
+		packageKey := pkg.Coordinate() + "@" + pkg.Version
 
 		if len(pkg.Licenses) == 0 {
 			// Package with no licenses
@@ -711,9 +711,9 @@ func filterResultByPackage(result *grant.RunResponse, packageName string) *grant
 	for _, target := range result.Run.Targets {
 		matchedPackages := []grant.PackageFinding{}
 
-		// Filter packages by name
+		// Filter packages by name, accepting either the bare name or the group-qualified form
 		for _, pkg := range target.Evaluation.Findings.Packages {
-			if pkg.Name == packageName {
+			if pkg.Name == packageName || pkg.Coordinate() == packageName {
 				matchedPackages = append(matchedPackages, pkg)
 			}
 		}
@@ -867,7 +867,7 @@ func outputRiskGroupedTable(target grant.TargetResult) error {
 
 	// Process each package
 	for _, pkg := range target.Evaluation.Findings.Packages {
-		packageKey := pkg.Name + "@" + pkg.Version
+		packageKey := pkg.Coordinate() + "@" + pkg.Version
 
 		for _, license := range pkg.Licenses {
 			licenseKey := license.ID
@@ -983,6 +983,9 @@ func displayPackageDetails(result *grant.RunResponse, packageName string) error 
 		}
 
 		fmt.Printf("Name:     %s\n", pkg.Name)
+		if pkg.Group != "" {
+			fmt.Printf("Group:    %s\n", pkg.Group)
+		}
 		fmt.Printf("Version:  %s\n", pkg.Version)
 		fmt.Printf("Type:     %s\n", pkg.Type)
 		fmt.Printf("ID:       %s\n", pkg.ID)

--- a/cmd/grant/cli/command/root.go
+++ b/cmd/grant/cli/command/root.go
@@ -234,7 +234,7 @@ func filterGrantJSONByLicenses(result *grant.RunResponse, licenseFilters []strin
 
 			if hasMatchingLicense {
 				// Use package name + version as deduplication key
-				packageKey := pkg.Name + "@" + pkg.Version
+				packageKey := pkg.Coordinate() + "@" + pkg.Version
 				packageMap[packageKey] = pkg
 			}
 		}

--- a/cmd/grant/cli/command/root.go
+++ b/cmd/grant/cli/command/root.go
@@ -234,7 +234,7 @@ func filterGrantJSONByLicenses(result *grant.RunResponse, licenseFilters []strin
 
 			if hasMatchingLicense {
 				// Use package name + version as deduplication key
-				packageKey := pkg.Coordinate() + "@" + pkg.Version
+				packageKey := pkg.QualifiedName() + "@" + pkg.Version
 				packageMap[packageKey] = pkg
 			}
 		}

--- a/cmd/grant/cli/internal/output.go
+++ b/cmd/grant/cli/internal/output.go
@@ -358,10 +358,10 @@ func (o *Output) OutputQuiet(result *grant.RunResponse) error {
 
 // printAggregatedLicenseTable prints licenses grouped by license name with package counts
 func (o *Output) printAggregatedLicenseTable(packages []grant.PackageFinding) error {
-	// First, deduplicate packages by name@version
+	// First, deduplicate packages by qualified name@version
 	uniquePackages := make(map[string]grant.PackageFinding)
 	for _, pkg := range packages {
-		packageKey := pkg.Name + "@" + pkg.Version
+		packageKey := pkg.Coordinate() + "@" + pkg.Version
 		uniquePackages[packageKey] = pkg
 	}
 
@@ -369,7 +369,7 @@ func (o *Output) printAggregatedLicenseTable(packages []grant.PackageFinding) er
 	licensePackages := make(map[string]map[string]bool)
 
 	for _, pkg := range uniquePackages {
-		packageKey := pkg.Name + "@" + pkg.Version
+		packageKey := pkg.Coordinate() + "@" + pkg.Version
 
 		if len(pkg.Licenses) == 0 {
 			// Package with no licenses

--- a/cmd/grant/cli/internal/output.go
+++ b/cmd/grant/cli/internal/output.go
@@ -361,7 +361,7 @@ func (o *Output) printAggregatedLicenseTable(packages []grant.PackageFinding) er
 	// First, deduplicate packages by qualified name@version
 	uniquePackages := make(map[string]grant.PackageFinding)
 	for _, pkg := range packages {
-		packageKey := pkg.Coordinate() + "@" + pkg.Version
+		packageKey := pkg.QualifiedName() + "@" + pkg.Version
 		uniquePackages[packageKey] = pkg
 	}
 
@@ -369,7 +369,7 @@ func (o *Output) printAggregatedLicenseTable(packages []grant.PackageFinding) er
 	licensePackages := make(map[string]map[string]bool)
 
 	for _, pkg := range uniquePackages {
-		packageKey := pkg.Coordinate() + "@" + pkg.Version
+		packageKey := pkg.QualifiedName() + "@" + pkg.Version
 
 		if len(pkg.Licenses) == 0 {
 			// Package with no licenses

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/anchore/clio v0.1.1
 	github.com/anchore/go-collections v0.1.1
 	github.com/anchore/go-logger v0.1.1
+	github.com/anchore/packageurl-go v0.2.0
 	github.com/anchore/stereoscope v0.3.0
 	github.com/anchore/syft v1.50.0
 	github.com/github/go-spdx/v2 v2.7.0
@@ -58,7 +59,6 @@ require (
 	github.com/anchore/go-struct-converter v0.2.0-rc2 // indirect
 	github.com/anchore/go-sync v0.1.1 // indirect
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b // indirect
-	github.com/anchore/packageurl-go v0.2.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aquasecurity/go-pep440-version v0.0.1 // indirect

--- a/grant/evaluation.go
+++ b/grant/evaluation.go
@@ -97,10 +97,10 @@ func (c *Case) catalogedPackageCount() int {
 	return count
 }
 
-// packageKey identifies a package for deduplication. Name, version, and type
-// together distinguish a real package
-func packageKey(name, version, pkgType string) string {
-	return name + "@" + version + "@" + pkgType
+// packageKey identifies a package for deduplication. The qualified name (see
+// Package.Coordinate), version, and type together distinguish a real package
+func packageKey(group, name, version, pkgType string) string {
+	return qualifyName(group, name) + "@" + version + "@" + pkgType
 }
 
 // mergeDuplicatePackages collapses every cataloged entry for a given package
@@ -113,7 +113,7 @@ func mergeDuplicatePackages(licensePackages map[string][]*Package, packagesNoLic
 	seenLocations := make(map[string]map[string]bool)
 
 	add := func(pkg Package) {
-		key := packageKey(pkg.Name, pkg.Version, pkg.Type)
+		key := packageKey(pkg.Group, pkg.Name, pkg.Version, pkg.Type)
 		current, ok := merged[key]
 		if !ok {
 			clone := pkg
@@ -165,7 +165,7 @@ func mergeDuplicatePackages(licensePackages map[string][]*Package, packagesNoLic
 // evaluatePackage evaluates a single package with licenses against the policy
 func (c *Case) evaluatePackage(pkg *Package, policy *Policy) PackageResult {
 	// Check if package should be ignored
-	if policy.IsPackageIgnored(pkg.Name) {
+	if policy.isPackageIgnored(*pkg) {
 		return PackageResult{
 			Package: *pkg,
 			Reason:  reasonPackageIgnored,
@@ -229,7 +229,7 @@ func (c *Case) evaluatePackage(pkg *Package, policy *Policy) PackageResult {
 // evaluatePackageNoLicense evaluates a package that has no licenses
 func (c *Case) evaluatePackageNoLicense(pkg *Package, policy *Policy) PackageResult {
 	// Check if package should be ignored
-	if policy.IsPackageIgnored(pkg.Name) {
+	if policy.isPackageIgnored(*pkg) {
 		return PackageResult{
 			Package: *pkg,
 			Reason:  reasonPackageIgnored,

--- a/grant/evaluation.go
+++ b/grant/evaluation.go
@@ -98,7 +98,7 @@ func (c *Case) catalogedPackageCount() int {
 }
 
 // packageKey identifies a package for deduplication. The qualified name (see
-// Package.Coordinate), version, and type together distinguish a real package
+// Package.QualifiedName), version, and type together distinguish a real package
 func packageKey(group, name, version, pkgType string) string {
 	return qualifyName(group, name) + "@" + version + "@" + pkgType
 }

--- a/grant/evaluation_test.go
+++ b/grant/evaluation_test.go
@@ -460,12 +460,12 @@ func TestMergeDuplicatePackages(t *testing.T) {
 
 	byKey := make(map[string]*Package)
 	for _, p := range merged {
-		byKey[packageKey(p.Name, p.Version, p.Type)] = p
+		byKey[packageKey(p.Group, p.Name, p.Version, p.Type)] = p
 	}
 
 	require.Len(t, byKey, 3, "expected 3 distinct packages: python@1.0.0, python@2.0.0, npm@1.0.0")
 
-	v1 := byKey[packageKey("dup-pkg", "1.0.0", "python")]
+	v1 := byKey[packageKey("", "dup-pkg", "1.0.0", "python")]
 	require.NotNil(t, v1, "missing merged dup-pkg@1.0.0 (python)")
 
 	// licenses are unioned across all three entries
@@ -476,8 +476,8 @@ func TestMergeDuplicatePackages(t *testing.T) {
 		"dup-pkg@1.0.0 should union locations without duplicates")
 
 	// a different version and a different type stay separate
-	assert.Contains(t, byKey, packageKey("dup-pkg", "2.0.0", "python"), "distinct version should be kept separate")
-	assert.Contains(t, byKey, packageKey("dup-pkg", "1.0.0", "npm"), "distinct type should be kept separate from the python package of the same name@version")
+	assert.Contains(t, byKey, packageKey("", "dup-pkg", "2.0.0", "python"), "distinct version should be kept separate")
+	assert.Contains(t, byKey, packageKey("", "dup-pkg", "1.0.0", "npm"), "distinct type should be kept separate from the python package of the same name@version")
 }
 
 // Helper function to create a Case from packages for testing

--- a/grant/package.go
+++ b/grant/package.go
@@ -1,6 +1,11 @@
 package grant
 
-import syftPkg "github.com/anchore/syft/syft/pkg"
+import (
+	"strings"
+
+	"github.com/anchore/packageurl-go"
+	syftPkg "github.com/anchore/syft/syft/pkg"
+)
 
 // PackageID is a unique identifier for a package that is tracked by grant
 // It's usually provided by the SBOM; It's calculated if an SBOM is generated
@@ -9,12 +14,31 @@ type PackageID string
 // Package is a package that is tracked by grant
 // These packages are decoded from SBOMs: spdx, cyclonedx, syft
 type Package struct {
-	ID        PackageID `json:"id" yaml:"id"`
-	Name      string    `json:"name" yaml:"name"`
+	ID PackageID `json:"id" yaml:"id"`
+	// Name is the package identity that policy and CLI filters match against, always exactly as
+	// the SBOM reports it
+	Name string `json:"name" yaml:"name"`
+	// Group is the namespace that qualifies Name where the ecosystem has one (the maven group id
+	// for java packages); it is empty for ecosystems without one
+	Group     string    `json:"group,omitempty" yaml:"group,omitempty"`
 	Type      string    `json:"type" yaml:"type"`
 	Version   string    `json:"version" yaml:"version"`
 	Licenses  []License `json:"licenses" yaml:"licenses"`
 	Locations []string  `json:"locations" yaml:"locations"`
+}
+
+// Coordinate is the fully qualified identity of a package, used to tell apart two packages that
+// share a name under different groups. Name alone remains the matching identity.
+func (p Package) Coordinate() string {
+	return qualifyName(p.Group, p.Name)
+}
+
+func qualifyName(group, name string) string {
+	if group == "" {
+		return name
+	}
+
+	return group + ":" + name
 }
 
 func ConvertSyftPackage(p syftPkg.Package) *Package {
@@ -26,9 +50,72 @@ func ConvertSyftPackage(p syftPkg.Package) *Package {
 
 	return &Package{
 		Name:      p.Name,
+		Group:     packageGroupFromSyft(p),
 		Version:   p.Version,
 		Type:      string(p.Type),
 		Licenses:  ConvertSyftLicenses(p.Licenses),
 		Locations: packageLocations,
 	}
+}
+
+func packageGroupFromSyft(p syftPkg.Package) string {
+	metadata, hasJavaMetadata := javaArchiveMetadata(p)
+	if !hasJavaMetadata && p.Type != syftPkg.JavaPkg {
+		return ""
+	}
+
+	groupID := javaGroupID(metadata, mavenPURL(p.PURL))
+	if groupID == p.Name {
+		return ""
+	}
+
+	return groupID
+}
+
+func javaArchiveMetadata(p syftPkg.Package) (syftPkg.JavaArchive, bool) {
+	switch metadata := p.Metadata.(type) {
+	case syftPkg.JavaArchive:
+		return metadata, true
+	case *syftPkg.JavaArchive:
+		if metadata != nil {
+			return *metadata, true
+		}
+	}
+
+	return syftPkg.JavaArchive{}, false
+}
+
+// mavenPURL parses a maven purl, whose namespace and name are the group and artifact ids. SBOM
+// formats that drop the pom metadata on decode still round-trip the purl, so it is the most
+// widely available source of maven coordinates.
+func mavenPURL(rawPURL string) packageurl.PackageURL {
+	if rawPURL == "" {
+		return packageurl.PackageURL{}
+	}
+
+	purl, err := packageurl.FromString(rawPURL)
+	if err != nil || purl.Type != packageurl.TypeMaven {
+		return packageurl.PackageURL{}
+	}
+
+	return purl
+}
+
+// javaGroupID returns the maven group id from whichever source carries it: archives with an
+// embedded pom.properties populate PomProperties, the pom.xml and gradle lockfile catalogers
+// populate PomProject, and decoded SBOMs may only have the purl.
+func javaGroupID(metadata syftPkg.JavaArchive, purl packageurl.PackageURL) string {
+	if metadata.PomProperties != nil {
+		if groupID := strings.TrimSpace(metadata.PomProperties.GroupID); groupID != "" {
+			return groupID
+		}
+	}
+
+	if metadata.PomProject != nil {
+		if groupID := strings.TrimSpace(metadata.PomProject.GroupID); groupID != "" {
+			return groupID
+		}
+	}
+
+	return strings.TrimSpace(purl.Namespace)
 }

--- a/grant/package.go
+++ b/grant/package.go
@@ -27,9 +27,9 @@ type Package struct {
 	Locations []string  `json:"locations" yaml:"locations"`
 }
 
-// Coordinate is the fully qualified identity of a package, used to tell apart two packages that
+// QualifiedName is the fully qualified identity of a package, used to tell apart two packages that
 // share a name under different groups. Name alone remains the matching identity.
-func (p Package) Coordinate() string {
+func (p Package) QualifiedName() string {
 	return qualifyName(p.Group, p.Name)
 }
 

--- a/grant/package_test.go
+++ b/grant/package_test.go
@@ -163,9 +163,9 @@ func TestConvertSyftPackage_MavenGroup(t *testing.T) {
 	}
 }
 
-func TestPackageCoordinate(t *testing.T) {
-	assert.Equal(t, "org.slf4j:slf4j-api", Package{Group: "org.slf4j", Name: "slf4j-api"}.Coordinate())
-	assert.Equal(t, "requests", Package{Name: "requests"}.Coordinate())
+func TestPackageQualifiedName(t *testing.T) {
+	assert.Equal(t, "org.slf4j:slf4j-api", Package{Group: "org.slf4j", Name: "slf4j-api"}.QualifiedName())
+	assert.Equal(t, "requests", Package{Name: "requests"}.QualifiedName())
 }
 
 func TestMergeDuplicatePackages_KeepsDistinctGroupsSeparate(t *testing.T) {
@@ -179,7 +179,7 @@ func TestMergeDuplicatePackages_KeepsDistinctGroupsSeparate(t *testing.T) {
 	assert.Len(t, merged, 2, "same artifact id under different groups must not be merged")
 }
 
-func TestPolicyIsPackageIgnored_MatchesNameOrCoordinate(t *testing.T) {
+func TestPolicyIsPackageIgnored_MatchesNameOrQualifiedName(t *testing.T) {
 	pkg := Package{Name: "core", Group: "com.foo", Version: "1.0.0", Type: "java-archive"}
 
 	assert.True(t, (&Policy{IgnorePackages: []string{"core"}}).isPackageIgnored(pkg),

--- a/grant/package_test.go
+++ b/grant/package_test.go
@@ -1,0 +1,191 @@
+package grant
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func TestConvertSyftPackage_MavenGroup(t *testing.T) {
+	tests := []struct {
+		name          string
+		syftPkg       pkg.Package
+		expectedName  string
+		expectedGroup string
+	}{
+		{
+			name: "reads the group from pom properties",
+			syftPkg: pkg.Package{
+				Name:    "slf4j-api",
+				Version: "2.0.17",
+				Type:    pkg.JavaPkg,
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{GroupID: "org.slf4j"},
+				},
+			},
+			expectedName:  "slf4j-api",
+			expectedGroup: "org.slf4j",
+		},
+		{
+			name: "falls back to the pom project group",
+			syftPkg: pkg.Package{
+				Name:    "commons-text",
+				Version: "1.10.0",
+				Type:    pkg.JavaPkg,
+				Metadata: pkg.JavaArchive{
+					PomProject: &pkg.JavaPomProject{GroupID: "org.apache.commons", ArtifactID: "commons-text"},
+				},
+			},
+			expectedName:  "commons-text",
+			expectedGroup: "org.apache.commons",
+		},
+		{
+			name: "prefers the pom properties group over the pom project group",
+			syftPkg: pkg.Package{
+				Name:    "commons-text",
+				Version: "1.10.0",
+				Type:    pkg.JavaPkg,
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{GroupID: "org.apache.commons"},
+					PomProject:    &pkg.JavaPomProject{GroupID: "org.apache.commons.shaded"},
+				},
+			},
+			expectedName:  "commons-text",
+			expectedGroup: "org.apache.commons",
+		},
+		{
+			name: "reads java metadata by pointer",
+			syftPkg: pkg.Package{
+				Name:    "slf4j-api",
+				Version: "2.0.17",
+				Type:    pkg.JavaPkg,
+				Metadata: &pkg.JavaArchive{
+					PomProject: &pkg.JavaPomProject{GroupID: "org.slf4j"},
+				},
+			},
+			expectedName:  "slf4j-api",
+			expectedGroup: "org.slf4j",
+		},
+		{
+			name: "falls back to the purl when the sbom dropped the pom metadata",
+			syftPkg: pkg.Package{
+				Name:     "slf4j-api",
+				Version:  "2.0.17",
+				Type:     pkg.JavaPkg,
+				PURL:     "pkg:maven/org.slf4j/slf4j-api@2.0.17",
+				Metadata: pkg.JavaArchive{},
+			},
+			expectedName:  "slf4j-api",
+			expectedGroup: "org.slf4j",
+		},
+		{
+			name: "falls back to the purl when there is no java metadata at all",
+			syftPkg: pkg.Package{
+				Name:    "slf4j-api",
+				Version: "2.0.17",
+				Type:    pkg.JavaPkg,
+				PURL:    "pkg:maven/org.slf4j/slf4j-api@2.0.17",
+			},
+			expectedName:  "slf4j-api",
+			expectedGroup: "org.slf4j",
+		},
+		{
+			name: "prefers the pom metadata over the purl",
+			syftPkg: pkg.Package{
+				Name:    "slf4j-api",
+				Version: "2.0.17",
+				Type:    pkg.JavaPkg,
+				PURL:    "pkg:maven/org.slf4j.shaded/slf4j-api@2.0.17",
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{GroupID: "org.slf4j"},
+				},
+			},
+			expectedName:  "slf4j-api",
+			expectedGroup: "org.slf4j",
+		},
+		{
+			name: "ignores a non-maven purl",
+			syftPkg: pkg.Package{
+				Name:     "some-shaded-jar",
+				Version:  "1.0.0",
+				Type:     pkg.JavaPkg,
+				PURL:     "pkg:generic/some-shaded-jar@1.0.0",
+				Metadata: pkg.JavaArchive{},
+			},
+			expectedName:  "some-shaded-jar",
+			expectedGroup: "",
+		},
+		{
+			name: "leaves java packages without a group unqualified",
+			syftPkg: pkg.Package{
+				Name:     "some-shaded-jar",
+				Version:  "1.0.0",
+				Type:     pkg.JavaPkg,
+				Metadata: pkg.JavaArchive{PomProperties: &pkg.JavaPomProperties{}},
+			},
+			expectedName:  "some-shaded-jar",
+			expectedGroup: "",
+		},
+		{
+			name: "does not repeat a name that is already the group",
+			syftPkg: pkg.Package{
+				Name:    "org.slf4j",
+				Version: "2.0.17",
+				Type:    pkg.JavaPkg,
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{GroupID: "org.slf4j"},
+				},
+			},
+			expectedName:  "org.slf4j",
+			expectedGroup: "",
+		},
+		{
+			name: "leaves non-java packages ungrouped",
+			syftPkg: pkg.Package{
+				Name:    "requests",
+				Version: "2.32.3",
+				Type:    pkg.PythonPkg,
+				PURL:    "pkg:pypi/requests@2.32.3",
+			},
+			expectedName:  "requests",
+			expectedGroup: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converted := ConvertSyftPackage(tt.syftPkg)
+			assert.Equal(t, tt.expectedName, converted.Name, "name must stay exactly as the sbom reports it")
+			assert.Equal(t, tt.expectedGroup, converted.Group)
+		})
+	}
+}
+
+func TestPackageCoordinate(t *testing.T) {
+	assert.Equal(t, "org.slf4j:slf4j-api", Package{Group: "org.slf4j", Name: "slf4j-api"}.Coordinate())
+	assert.Equal(t, "requests", Package{Name: "requests"}.Coordinate())
+}
+
+func TestMergeDuplicatePackages_KeepsDistinctGroupsSeparate(t *testing.T) {
+	packages := []Package{
+		{Name: "core", Group: "com.foo", Version: "1.0.0", Type: "java-archive"},
+		{Name: "core", Group: "com.bar", Version: "1.0.0", Type: "java-archive"},
+	}
+
+	merged := mergeDuplicatePackages(nil, packages)
+
+	assert.Len(t, merged, 2, "same artifact id under different groups must not be merged")
+}
+
+func TestPolicyIsPackageIgnored_MatchesNameOrCoordinate(t *testing.T) {
+	pkg := Package{Name: "core", Group: "com.foo", Version: "1.0.0", Type: "java-archive"}
+
+	assert.True(t, (&Policy{IgnorePackages: []string{"core"}}).isPackageIgnored(pkg),
+		"an existing bare-name pattern must keep matching")
+	assert.True(t, (&Policy{IgnorePackages: []string{"com.foo:core"}}).isPackageIgnored(pkg),
+		"a group-qualified pattern should match")
+	assert.False(t, (&Policy{IgnorePackages: []string{"com.bar:core"}}).isPackageIgnored(pkg),
+		"a pattern for another group should not match")
+}

--- a/grant/policy.go
+++ b/grant/policy.go
@@ -85,6 +85,20 @@ func (p *Policy) IsPackageIgnored(packageName string) bool {
 	return false
 }
 
+// isPackageIgnored checks a package against ignore-packages, accepting either its bare name or its
+// group-qualified coordinate so a pattern can target one group without affecting the other.
+func (p *Policy) isPackageIgnored(pkg Package) bool {
+	if p.IsPackageIgnored(pkg.Name) {
+		return true
+	}
+
+	if coordinate := pkg.Coordinate(); coordinate != pkg.Name {
+		return p.IsPackageIgnored(coordinate)
+	}
+
+	return false
+}
+
 // LoadPolicy loads a policy from YAML bytes
 func LoadPolicy(data []byte) (*Policy, error) {
 	var policy Policy

--- a/grant/policy.go
+++ b/grant/policy.go
@@ -86,14 +86,14 @@ func (p *Policy) IsPackageIgnored(packageName string) bool {
 }
 
 // isPackageIgnored checks a package against ignore-packages, accepting either its bare name or its
-// group-qualified coordinate so a pattern can target one group without affecting the other.
+// group-qualified name so a pattern can target one group without affecting the other.
 func (p *Policy) isPackageIgnored(pkg Package) bool {
 	if p.IsPackageIgnored(pkg.Name) {
 		return true
 	}
 
-	if coordinate := pkg.Coordinate(); coordinate != pkg.Name {
-		return p.IsPackageIgnored(coordinate)
+	if qualified := pkg.QualifiedName(); qualified != pkg.Name {
+		return p.IsPackageIgnored(qualified)
 	}
 
 	return false

--- a/grant/response.go
+++ b/grant/response.go
@@ -103,11 +103,18 @@ type EvaluationFindings struct {
 type PackageFinding struct {
 	ID        string          `json:"id"`
 	Name      string          `json:"name"`
+	Group     string          `json:"group,omitempty"`
 	Type      string          `json:"type"`
 	Version   string          `json:"version"`
 	Decision  string          `json:"decision"` // allow | deny | ignore
 	Licenses  []LicenseDetail `json:"licenses"`
 	Locations []string        `json:"locations"`
+}
+
+// Coordinate is the fully qualified identity of the package, used to tell apart two findings that
+// share a name under different groups. Name alone remains the matching identity.
+func (f PackageFinding) Coordinate() string {
+	return qualifyName(f.Group, f.Name)
 }
 
 // LicenseDetail contains detailed license information
@@ -234,7 +241,7 @@ func calculateLicenseStatistics(evalResult *EvaluationResult) licenseStatistics 
 }
 
 // buildEvaluationFindings creates findings from evaluation results, keyed by
-// name@version. Evaluate already collapses each cataloged package to a single
+// packageKey. Evaluate already collapses each cataloged package to a single
 // category, so a package appears in exactly one of the result buckets here.
 func buildEvaluationFindings(evalResult *EvaluationResult) EvaluationFindings {
 	findings := EvaluationFindings{
@@ -246,7 +253,7 @@ func buildEvaluationFindings(evalResult *EvaluationResult) EvaluationFindings {
 	// Add allowed packages
 	for _, pkg := range evalResult.AllowedPackages {
 		finding := packageToFinding(pkg.Package, DecisionAllow)
-		key := packageKey(finding.Name, finding.Version, finding.Type)
+		key := packageKey(finding.Group, finding.Name, finding.Version, finding.Type)
 		if _, exists := packageMap[key]; !exists {
 			packageMap[key] = finding
 		}
@@ -255,7 +262,7 @@ func buildEvaluationFindings(evalResult *EvaluationResult) EvaluationFindings {
 	// Add denied packages
 	for _, pkg := range evalResult.DeniedPackages {
 		finding := packageToFindingWithDeniedLicenses(pkg.Package, DecisionDeny, pkg.DeniedLicenses)
-		key := packageKey(finding.Name, finding.Version, finding.Type)
+		key := packageKey(finding.Group, finding.Name, finding.Version, finding.Type)
 		if _, exists := packageMap[key]; !exists {
 			packageMap[key] = finding
 		}
@@ -264,7 +271,7 @@ func buildEvaluationFindings(evalResult *EvaluationResult) EvaluationFindings {
 	// Add ignored packages
 	for _, pkg := range evalResult.IgnoredPackages {
 		finding := packageToFinding(pkg.Package, DecisionIgnore)
-		key := packageKey(finding.Name, finding.Version, finding.Type)
+		key := packageKey(finding.Group, finding.Name, finding.Version, finding.Type)
 		if _, exists := packageMap[key]; !exists {
 			packageMap[key] = finding
 		}
@@ -325,6 +332,7 @@ func packageToFinding(pkg Package, decision string) PackageFinding {
 	return PackageFinding{
 		ID:        pkgID,
 		Name:      pkg.Name,
+		Group:     pkg.Group,
 		Type:      pkg.Type,
 		Version:   pkg.Version,
 		Decision:  decision,
@@ -376,6 +384,7 @@ func packageToFindingWithDeniedLicenses(pkg Package, decision string, deniedLice
 	return PackageFinding{
 		ID:        pkgID,
 		Name:      pkg.Name,
+		Group:     pkg.Group,
 		Type:      pkg.Type,
 		Version:   pkg.Version,
 		Decision:  decision,

--- a/grant/response.go
+++ b/grant/response.go
@@ -111,9 +111,9 @@ type PackageFinding struct {
 	Locations []string        `json:"locations"`
 }
 
-// Coordinate is the fully qualified identity of the package, used to tell apart two findings that
+// QualifiedName is the fully qualified identity of the package, used to tell apart two findings that
 // share a name under different groups. Name alone remains the matching identity.
-func (f PackageFinding) Coordinate() string {
+func (f PackageFinding) QualifiedName() string {
 	return qualifyName(f.Group, f.Name)
 }
 


### PR DESCRIPTION
Two java packages with the same artifact id under different maven groups (com.foo:core, com.bar:core) collapsed into a single entry, sharing one license set and one verdict.

Add Package.Group alongside Name rather than folding the group into the name, so package identity for policy and CLI filters is unchanged. The group resolves from PomProperties, then PomProject, then the purl namespace, and qualifies the package as "group:name" for deduplication.

Supersedes #543.